### PR TITLE
Fix cron doesn't fire

### DIFF
--- a/bfx-pay-woocommerce.php
+++ b/bfx-pay-woocommerce.php
@@ -23,13 +23,44 @@ if (!in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get
 add_action('plugins_loaded', 'bfx_pay_woocommerce_init', 11);
 add_action('woocommerce_after_add_to_cart_form', 'bfx_pay_buy_checkout_on_archive');
 add_action('template_redirect', 'bfx_pay_addtocart_on_archives_redirect_checkout');
-add_action('wp_mail_failed', 'log_mailer_errors', 10, 1);
+// add_action('wp_mail_failed', 'log_mailer_errors', 10, 1);
 
 add_filter('plugin_action_links_' . plugin_basename(__FILE__), 'bfx_pay_settings_link', 10);
 add_filter('woocommerce_payment_gateways', 'bfx_pay_add_bfx_payment_gateway_woo');
 add_filter('plugin_row_meta', 'bfx_pay_plugin_row_meta', 10, 3);
 
 add_filter('pre_option_woocommerce_currency_pos', 'currency_position');
+
+
+// Cron
+add_filter('cron_schedules', 'bfx_pay_cron_add_fifteen_min');
+add_action( 'bfx_pay_cron_hook', 'bfx_pay_cron_exec' );
+add_action('wp', 'bfx_pay_add_cron');
+
+
+function bfx_pay_cron_add_fifteen_min($schedules)
+{
+    $schedules['bfx_pay_fifteen_min'] = [
+        'interval' => 60 * 15,
+        'display' => 'Every 15 minute',
+    ];
+
+    return $schedules;
+}
+
+function bfx_pay_cron_exec() {
+    if (class_exists('WC_Bfx_Pay_Gateway')) {
+        $instance = new WC_Bfx_Pay_Gateway();
+        $instance->cron_invoice_check();
+    }
+}
+
+function bfx_pay_add_cron() {
+    if ( ! wp_next_scheduled( 'bfx_pay_cron_hook' ) ) {
+        wp_schedule_event( time(), 'bfx_pay_fifteen_min', 'bfx_pay_cron_hook' );
+    }
+}
+
 
 function currency_position()
 {


### PR DESCRIPTION
There are 2 problems with the existing implementation
- `wc_add_notice($responsein, 'notice')` can't be used in a cron. It's only available in end-user site.
- Declaring hook inside the class doesn't work, because when the cron is trigger the class is not loaded.